### PR TITLE
fix(footer): update copyright year automatically

### DIFF
--- a/src/sections/Footer/index.tsx
+++ b/src/sections/Footer/index.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 
 export default function Footer() {
+  const currentYear: number = new Date().getFullYear();
   return (
     <h1 className="w-full py-4 text-center text-xs sm:text-base" id="footer">
-      Haopeng Zeng © 2023. All rights reserved.
+      Haopeng Zeng © {currentYear}. All rights reserved.
     </h1>
   );
 }


### PR DESCRIPTION
This commit ensures the copyright year in the footer section is always up-to-date.

To be honest, I am not sure how the legal system works. If the copyright year does not need to be updated, please let me know, and I'll close this PR.

Anyway, I am impressed by your work. Your website is beautiful. Great job!